### PR TITLE
Add 'debug' config option for logging structure creation to the console

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,9 @@ configversion: 3
 #========================================
 #Wiki: https://github.com/ryandw11/CustomStructures/wiki
 
+#Log extra information in console when generating structures
+debug: false
+
 #Allow Plugins to delete structures at will.
 allowDeletion: true
 

--- a/src/com/ryandw11/structure/SchematicHandeler.java
+++ b/src/com/ryandw11/structure/SchematicHandeler.java
@@ -108,6 +108,10 @@ public class SchematicHandeler {
 			Operation operation = ch.createPaste(editSession)
 					.to(BlockVector3.at(loc.getX(), loc.getY(), loc.getZ())).ignoreAirBlocks(!useAir).build();
 			Operations.complete(operation);
+
+			if(plugin.getConfig().getBoolean("debug")){
+				plugin.getLogger().info("Created an instance of " + filename + " at " + loc.toString());
+			}
 		}
 
 		this.plugin.getServer().getScheduler().scheduleSyncDelayedTask(this.plugin, new Runnable() {


### PR DESCRIPTION
Add a new 'debug' option to config.yml. When enabled, the generation of new structures, including their name and location, is logged to the console.