### PR TITLE
Fix container & sign replacement in randomly rotated structures

### DIFF
--- a/src/com/ryandw11/structure/utils/GetBlocksInArea.java
+++ b/src/com/ryandw11/structure/utils/GetBlocksInArea.java
@@ -1,0 +1,26 @@
+package com.ryandw11.structure.utils;
+
+import org.bukkit.Location;
+
+import java.util.ArrayList;
+
+//Thanks Cycryl! https://www.spigotmc.org/threads/getting-all-blocks-between-to-locations.272852/
+
+public class GetBlocksInArea {
+    public static ArrayList<Location> getLocationListBetween(Location loc1, Location loc2){
+        int lowX = Math.min(loc1.getBlockX(), loc2.getBlockX());
+        int lowY = Math.min(loc1.getBlockY(), loc2.getBlockY());
+        int lowZ = Math.min(loc1.getBlockZ(), loc2.getBlockZ());
+
+        ArrayList<Location> locs = new ArrayList<>();
+
+        for(int x = 0; x<=Math.abs(loc1.getBlockX()-loc2.getBlockX()); x++){
+            for(int y = 0; y<=Math.abs(loc1.getBlockY()-loc2.getBlockY()); y++){
+                for(int z = 0; z<=Math.abs(loc1.getBlockZ()-loc2.getBlockZ()); z++){
+                    locs.add(new Location(loc1.getWorld(),lowX+x, lowY+y, lowZ+z));
+                }
+            }
+        }
+        return locs;
+    }
+}

--- a/src/com/ryandw11/structure/utils/RotatePointAround.java
+++ b/src/com/ryandw11/structure/utils/RotatePointAround.java
@@ -1,0 +1,14 @@
+package com.ryandw11.structure.utils;
+
+import com.sk89q.worldedit.math.BlockVector3;
+
+public class RotatePointAround {
+
+    public static BlockVector3 calculate(BlockVector3 point, BlockVector3 center, double angle){
+        angle = angle * -1 * (Math.PI/180);
+        double rotatedX = Math.cos(angle) * (point.getX() - center.getX()) - Math.sin(angle) * (point.getZ() - center.getZ()) + center.getX();
+        double rotatedZ = Math.sin(angle) * (point.getX() - center.getX()) + Math.cos(angle) * (point.getZ() - center.getZ()) + center.getZ();
+
+        return BlockVector3.at(rotatedX, point.getY(), rotatedZ);
+    }
+}


### PR DESCRIPTION
On structure generation, calculate the minimum & maximum points of the pasted structure's new location, taking rotation into account, and scan between them for loot containers to stock and mob signs to replace. Addresses #26, #44