### PR TITLE
Fix MythicMobs mobs not spawning from signs

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,7 @@ main: com.ryandw11.structure.CustomStructures
 author: Ryandw11
 description: A plugin which allows you to spawn in custom structures!
 depend: [WorldEdit]
-softdepend: [MythicalMobs]
+softdepend: [MythicMobs]
 api-version: 1.13
 commands:
     customstructure:

--- a/src/com/ryandw11/structure/CustomStructures.java
+++ b/src/com/ryandw11/structure/CustomStructures.java
@@ -55,9 +55,9 @@ public class CustomStructures extends JavaPlugin {
 		loadManager();
 		registerConfig();
 		
-		if(getServer().getPluginManager().getPlugin("MythicalMobs") != null) {
+		if(getServer().getPluginManager().getPlugin("MythicMobs") != null) {
 			mmh = new MMEnabled();
-			getLogger().info("MythicalMobs detected! Activating plugin hook!");
+			getLogger().info("MythicMobs detected! Activating plugin hook!");
 		}else {
 			mmh = new MMDisabled();
 		}

--- a/src/com/ryandw11/structure/mythicalmobs/MMDisabled.java
+++ b/src/com/ryandw11/structure/mythicalmobs/MMDisabled.java
@@ -7,8 +7,7 @@ public class MMDisabled implements MythicalMobHook{
 
 	@Override
 	public void spawnMob(String name, Location loc) {
-		Bukkit.getLogger().info("A schematic tried to spawn a MythicalMob! This server does not have the plugin installed!");
-		return;
+		Bukkit.getLogger().info("A schematic tried to spawn a MythicMob, but the server does not have that plugin installed!");
 	}
 
 }


### PR DESCRIPTION
List MythicMobs as a softdepend in plugin.yml so that CustomStructures will always load after MythicMobs if MythicMobs is present. This ensures that CustomStructures will be able to register its MythicMobs hook correctly. Addresses #32


Semi-related: While testing, I noticed that mythicmobs and regular mobs generated in randomly-occurring structures frequently spawn and then despawn again before the player who generated the chunk can reach them. 

MythicMobs mobs have a per-mob config option for getting around this with "Despawn: false" but it might be worth looking into an option to give all mobs spawned through CustomStructures the "PersistenceRequired" flag so that they won't spawn outside activation range and then despawn again before they're encountered.