### PR TITLE
Added StructureSectionProvider API for non-reflective StructureSection construction

### DIFF
--- a/src/main/java/com/ryandw11/structure/api/structaddon/CustomStructureAddon.java
+++ b/src/main/java/com/ryandw11/structure/api/structaddon/CustomStructureAddon.java
@@ -3,8 +3,7 @@ package com.ryandw11.structure.api.structaddon;
 import com.ryandw11.structure.CustomStructures;
 import org.bukkit.plugin.Plugin;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * This class is responsible for extending CustomStructure functionality.
@@ -19,6 +18,7 @@ import java.util.List;
 public final class CustomStructureAddon {
     private final String name;
     private final List<String> authors;
+    private final Set<StructureSectionProvider> providerSet = new HashSet<>();
     private final List<Class<? extends StructureSection>> structureSections;
 
     /**
@@ -69,11 +69,35 @@ public final class CustomStructureAddon {
     }
 
     /**
+     * Register StructureSectionProvider to the addon.
+     * @param provider The provider to register.
+     */
+    public void registerStructureSectionProvider(StructureSectionProvider provider) {
+        this.providerSet.add(provider);
+    }
+
+    /**
+     * Unregister StructureSectionProvider from the addon.
+     * @param provider
+     */
+    public void unregisterStructureSectionProvider(StructureSectionProvider provider) {
+        this.providerSet.remove(provider);
+    }
+
+    /**
      * Get the list of structure sections.
      *
      * @return The list of structure sections.
      */
     public List<Class<? extends StructureSection>> getStructureSections() {
         return this.structureSections;
+    }
+
+    /**
+     * Get all provider registered on this addon
+     * @return a set of provider
+     */
+    public Set<StructureSectionProvider> getProviderSet() {
+        return Collections.unmodifiableSet(this.providerSet);
     }
 }

--- a/src/main/java/com/ryandw11/structure/api/structaddon/StructureSectionProvider.java
+++ b/src/main/java/com/ryandw11/structure/api/structaddon/StructureSectionProvider.java
@@ -1,0 +1,12 @@
+package com.ryandw11.structure.api.structaddon;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface StructureSectionProvider {
+    /**
+     * Creates StructureSection
+     * @return The StructureSection provided by this provider
+     */
+    @NotNull
+    StructureSection createSection();
+}

--- a/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
+++ b/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
@@ -3,6 +3,7 @@ package com.ryandw11.structure.structure;
 import com.ryandw11.structure.CustomStructures;
 import com.ryandw11.structure.api.structaddon.CustomStructureAddon;
 import com.ryandw11.structure.api.structaddon.StructureSection;
+import com.ryandw11.structure.api.structaddon.StructureSectionProvider;
 import com.ryandw11.structure.exceptions.StructureConfigurationException;
 import com.ryandw11.structure.loottables.LootTable;
 import com.ryandw11.structure.loottables.LootTableType;
@@ -148,6 +149,29 @@ public class StructureBuilder {
 
         // Go through and setup the sections for the addons.
         for (CustomStructureAddon addon : CustomStructures.getInstance().getAddonHandler().getCustomStructureAddons()) {
+            for (StructureSectionProvider provider : addon.getProviderSet()) {
+                try {
+                    StructureSection section = provider.createSection();
+                    if (!config.contains(section.getName())) {
+                        section.setupSection(null);
+                    } else {
+                        section.setupSection(config.getConfigurationSection(section.getName()));
+                    }
+                    this.structureSections.add(section);
+                } catch (StructureConfigurationException ex) {
+                    // Handle the structureConfigurationException.
+                    throw new StructureConfigurationException(String.format("[%s Addon] %s. This is not" +
+                            "an issue with the CustomStructures plugin.", addon.getName(), ex.getMessage()));
+                } catch (Throwable ex) {
+                    // Inform the user of errors.
+                    plugin.getLogger().severe(String.format("An error was encountered in the %s addon! Enable debug for more information.", addon.getName()));
+                    plugin.getLogger().severe(ex.getMessage());
+                    plugin.getLogger().severe("This is not an issue with CustomStructures! Please contact the addon developer.");
+                    if (plugin.isDebug())
+                        ex.printStackTrace();
+                }
+            }
+
             for (Class<? extends StructureSection> section : addon.getStructureSections()) {
                 try {
                     StructureSection constructedSection = section.getConstructor().newInstance();


### PR DESCRIPTION
The reason behind this is that I have multiple sections that are created from another configuration. Using the current API, I don't want to generate class at runtime just to register those sections into the addon. The StructureSectionProvider provides StructureSection without having to create a class, you basically can create a StructureSection with the same class but (probably) with different parameters configured from the addon developer/user. This also reduces the amount of reflection operation.