### PR TITLE
Adding support for PAPI placeholders in sign commands and Citizen NPC names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -194,6 +198,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.9.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/ryandw11/structure/CustomStructures.java
+++ b/src/main/java/com/ryandw11/structure/CustomStructures.java
@@ -18,6 +18,7 @@ import com.ryandw11.structure.mythicalmobs.MythicalMobHook;
 import com.ryandw11.structure.structure.StructureHandler;
 import com.ryandw11.structure.utils.Pair;
 import com.ryandw11.structure.utils.SpawnYConversion;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.apache.commons.io.FileUtils;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
@@ -65,6 +66,8 @@ public class CustomStructures extends JavaPlugin {
     public static final int COMPILED_STRUCT_VER = 1;
     public static final int CONFIG_VERSION = 7;
 
+    private static boolean papiEnabled = false;
+
     @Override
     public void onEnable() {
         enabled = true;
@@ -73,6 +76,15 @@ public class CustomStructures extends JavaPlugin {
         loadManager();
         registerConfig();
         setupBlockIgnore();
+
+        // Small check to make sure that PlaceholderAPI is installed
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            this.getLogger().info("Placeholder API found, placeholders supported.");
+            CustomStructures.papiEnabled = true;
+        } else {
+            this.getLogger().info("PlaceholderAPI not found.");
+        }
+
 
         // Setup Citizens dependency.
         if (getServer().getPluginManager().getPlugin("Citizens") != null) {
@@ -142,6 +154,19 @@ public class CustomStructures extends JavaPlugin {
         } else {
             getLogger().info("Bstat metrics is disabled for this plugin.");
         }
+    }
+
+    /**
+     * Resolves PAPI placeholders.
+     *
+     * @param text The text which may contain placeholders.
+     * @return The final text.
+     */
+    public static String replacePAPIPlaceholders(String text) {
+        if(papiEnabled) {
+            return PlaceholderAPI.setPlaceholders(null, text);
+        }
+        return text;
     }
 
     /**

--- a/src/main/java/com/ryandw11/structure/SchematicHandler.java
+++ b/src/main/java/com/ryandw11/structure/SchematicHandler.java
@@ -618,6 +618,7 @@ public class SchematicHandler {
             if (commands != null) {
                 for (String command : commands) {
                     command = CSUtils.replacePlaceHolders(command, location, minLoc, maxLoc);
+                    command = CustomStructures.replacePAPIPlaceholders(command);
                     Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
                     if (plugin.isDebug()) {
                         plugin.getLogger().info("Executing console command: '" + command + "'");

--- a/src/main/java/com/ryandw11/structure/citizens/CitizensEnabled.java
+++ b/src/main/java/com/ryandw11/structure/citizens/CitizensEnabled.java
@@ -57,7 +57,10 @@ public class CitizensEnabled implements CitizensNpcHook {
             plugin.getLogger().warning("Unsupported NPC entity-type '" + info.entityType + "'! Spawning a villager instead.");
         }
 
-        NPC npc = CitizensAPI.getNPCRegistry().createNPC(type, info.name);
+        // Support PAPI for NPC names to be able to generate unique random names
+        String npcName = CustomStructures.replacePAPIPlaceholders(info.name);
+
+        NPC npc = CitizensAPI.getNPCRegistry().createNPC(type, npcName);
         int npcId = npc.getId();
 
         if (!npc.isSpawned()) {
@@ -79,6 +82,7 @@ public class CitizensEnabled implements CitizensNpcHook {
             for (String command : info.commandsOnCreate) {
                 command = command.trim();
                 command = command.replace("<npcid>", String.valueOf(npcId));
+                command = CustomStructures.replacePAPIPlaceholders(command);
                 // The [PLAYER] prefix is not supported here for obvious reasons
                 if (command.toUpperCase().startsWith("[PLAYER]")) {
                     // cut off the [PLAYER] prefix


### PR DESCRIPTION
This adds the PAPI plugin as a soft dependency, so CustomStructures will still work without it, only PAPI placeholder resolution will then not work. It allows to use PAPI placeholders in sign command strings, or the name of a Citizen NPC. Which allows me to use randomly generated unique names created by my own plugin, "NiceNameGenerator", to generate unique names for WorldGuard regions and NPCs.