### PR TITLE
1.8.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Custom Structures is a Minecraft server plugin that generates unique structures 
 - Spawn Mythical Mobs (Requires MythicalMobs)
 - Spawn Citizen NPCs, with custom skins, commands etc.
 - Execute console commands when structure spawns
+- Recursive Schematic Placement  

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
                 <configuration>
                     <relocations>
                         <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ryandw11</groupId>
     <artifactId>CustomStructures</artifactId>
-    <version>1.7.1.1</version>
+    <version>1.8.0</version>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -183,9 +183,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.lumine.xikage</groupId>
-            <artifactId>MythicMobs</artifactId>
-            <version>4.9.1</version>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-Dist</artifactId>
+            <version>5.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/src/main/java/com/ryandw11/structure/CustomStructures.java
+++ b/src/main/java/com/ryandw11/structure/CustomStructures.java
@@ -37,7 +37,7 @@ import java.util.*;
  * The main class for the Custom Structures plugin.
  *
  * @author Ryandw11
- * @version 1.7.0
+ * @version 1.8.0
  */
 
 public class CustomStructures extends JavaPlugin {
@@ -213,23 +213,12 @@ public class CustomStructures extends JavaPlugin {
 
         // Initialize blockIgnoreManager with the proper class for the version.
         switch (version) {
-            case "v1_16_R3":
-            case "v1_16_R2":
-            case "v1_16_R1":
-                blockIgnoreManager = new IgnoreBlocks_1_16();
-                break;
-            case "v1_15_R1":
-                blockIgnoreManager = new IgnoreBlocks_1_15();
-                break;
-            case "v1_14_R1":
-                blockIgnoreManager = new IgnoreBlocks_1_14();
-                break;
-            case "v1_13_R1":
-                blockIgnoreManager = new IgnoreBlocks_1_13();
-                break;
-            default:
-                blockIgnoreManager = new IgnoreBlocks_1_17();
-                break;
+            case "v1_18_R2", "v1_18_R1", "v1_17_R1" -> blockIgnoreManager = new IgnoreBlocks_1_17();
+            case "v1_16_R3", "v1_16_R2", "v1_16_R1" -> blockIgnoreManager = new IgnoreBlocks_1_16();
+            case "v1_15_R1" -> blockIgnoreManager = new IgnoreBlocks_1_15();
+            case "v1_14_R1" -> blockIgnoreManager = new IgnoreBlocks_1_14();
+            case "v1_13_R1" -> blockIgnoreManager = new IgnoreBlocks_1_13();
+            default -> blockIgnoreManager = new IgnoreBlocks_1_19();
         }
     }
 

--- a/src/main/java/com/ryandw11/structure/CustomStructures.java
+++ b/src/main/java/com/ryandw11/structure/CustomStructures.java
@@ -78,7 +78,7 @@ public class CustomStructures extends JavaPlugin {
         setupBlockIgnore();
 
         // Small check to make sure that PlaceholderAPI is installed
-        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             this.getLogger().info("Placeholder API found, placeholders supported.");
             CustomStructures.papiEnabled = true;
         } else {
@@ -128,7 +128,7 @@ public class CustomStructures extends JavaPlugin {
         this.addonHandler = new AddonHandler();
 
         // Run this after the loading of all plugins.
-        Bukkit.getScheduler().runTaskLater(this, () -> {
+        Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
             this.structureHandler = new StructureHandler(getConfig().getStringList("Structures"), this);
             getLogger().info("The plugin has been fully enabled with " + structureHandler.getStructures().size() + " structures.");
             getLogger().info(addonHandler.getCustomStructureAddons().size() + " addons were found.");
@@ -144,7 +144,7 @@ public class CustomStructures extends JavaPlugin {
                 }));
             }
 
-        }, 20);
+        }, 30);
 
 
         if (getConfig().getBoolean("bstats")) {
@@ -163,7 +163,7 @@ public class CustomStructures extends JavaPlugin {
      * @return The final text.
      */
     public static String replacePAPIPlaceholders(String text) {
-        if(papiEnabled) {
+        if (papiEnabled) {
             return PlaceholderAPI.setPlaceholders(null, text);
         }
         return text;

--- a/src/main/java/com/ryandw11/structure/SchematicHandler.java
+++ b/src/main/java/com/ryandw11/structure/SchematicHandler.java
@@ -3,6 +3,7 @@ package com.ryandw11.structure;
 import com.ryandw11.structure.api.LootPopulateEvent;
 import com.ryandw11.structure.api.StructureSpawnEvent;
 import com.ryandw11.structure.api.holder.StructureSpawnHolder;
+import com.ryandw11.structure.bottomfill.BottomFillProvider;
 import com.ryandw11.structure.io.BlockTag;
 import com.ryandw11.structure.loottables.LootTable;
 import com.ryandw11.structure.loottables.LootTableType;
@@ -156,6 +157,13 @@ public class SchematicHandler {
             if (plugin.getConfig().getBoolean("debug")) {
                 plugin.getLogger().info(String.format("(%s) Created an instance of %s at %s, %s, %s with rotation %s", loc.getWorld().getName(), filename, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), rotY));
             }
+        }
+
+        // If enabled, perform a bottom space fill.
+        if(structure.getBottomSpaceFill().isEnabled()) {
+            Location minLoc = getMinimumLocation(clipboard, loc, rotY);
+            Location maxLoc = getMaximumLocation(clipboard, loc, rotY);
+            BottomFillProvider.provide().performFill(structure, loc, minLoc, maxLoc);
         }
 
         //Schedule the signs & containers replacement task

--- a/src/main/java/com/ryandw11/structure/SchematicHandler.java
+++ b/src/main/java/com/ryandw11/structure/SchematicHandler.java
@@ -80,7 +80,7 @@ public class SchematicHandler {
     public void schemHandle(Location loc, String filename, boolean useAir, Structure structure, int iteration)
             throws IOException, WorldEditException {
 
-        if (iteration > 2) {
+        if (iteration > structure.getStructureLimitations().getIterationLimit()) {
             plugin.getLogger().severe("Critical Error: StackOverflow detected. Automatically terminating the spawning of the structure.");
             plugin.getLogger().severe("The structure '" + structure.getName() + "' has spawned too many sub structure via recursion.");
             return;

--- a/src/main/java/com/ryandw11/structure/SchematicHandler.java
+++ b/src/main/java/com/ryandw11/structure/SchematicHandler.java
@@ -12,6 +12,7 @@ import com.ryandw11.structure.structure.properties.MaskProperty;
 import com.ryandw11.structure.structure.properties.SubSchematics;
 import com.ryandw11.structure.structure.properties.schematics.SubSchematic;
 import com.ryandw11.structure.utils.CSUtils;
+import com.ryandw11.structure.utils.NumberStylizer;
 import com.ryandw11.structure.utils.RandomCollection;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.IncompleteRegionException;
@@ -637,7 +638,7 @@ public class SchematicHandler {
             if (!thirdLine.isEmpty()) {
                 try {
                     // Impose a maximum limit of 40 mobs.
-                    count = Math.min(Integer.parseInt(thirdLine), 40);
+                    count = Math.min(NumberStylizer.getStylizedInt(thirdLine), 40);
                 } catch (NumberFormatException ex) {
                     // Ignore, keep count as 1.
                 }
@@ -685,7 +686,7 @@ public class SchematicHandler {
             if (!fourthLine.isEmpty()) {
                 try {
                     // Impose a maximum limit of 40 mobs.
-                    count = Math.min(Integer.parseInt(fourthLine), 40);
+                    count = Math.min(NumberStylizer.getStylizedInt(fourthLine), 40);
                 } catch (NumberFormatException ex) {
                     // Ignore, keep count as 1.
                 }
@@ -746,6 +747,8 @@ public class SchematicHandler {
             if (secondLine.startsWith("[")) {
                 String v = secondLine.replace("[", "").replace("]", "");
                 String[] out = v.split("-");
+                if (out.length == 1)
+                    out = v.split(";");
                 try {
                     int num1 = Integer.parseInt(out[0]);
                     int num2 = Integer.parseInt(out[1]);

--- a/src/main/java/com/ryandw11/structure/bottomfill/BottomFillImpl.java
+++ b/src/main/java/com/ryandw11/structure/bottomfill/BottomFillImpl.java
@@ -1,0 +1,23 @@
+package com.ryandw11.structure.bottomfill;
+
+import com.ryandw11.structure.structure.Structure;
+import org.bukkit.Location;
+
+/**
+ * The interface for bottom fill implementations.
+ *
+ * <p>Use the {@link BottomFillProvider} to get the correct implementation and register a new one.</p>
+ */
+public interface BottomFillImpl {
+    /**
+     * Called by the plugin when a bottom fill should be performed.
+     *
+     * <p>This will only be called if the BottomFill option is enabled.</p>
+     *
+     * @param structure The structure that was spawned.
+     * @param spawnLocation The spawn location.
+     * @param minLoc The minimum location.
+     * @param maxLoc The maximum location.
+     */
+    void performFill(Structure structure, Location spawnLocation, Location minLoc, Location maxLoc);
+}

--- a/src/main/java/com/ryandw11/structure/bottomfill/BottomFillProvider.java
+++ b/src/main/java/com/ryandw11/structure/bottomfill/BottomFillProvider.java
@@ -22,7 +22,7 @@ public final class BottomFillProvider {
      * Get a bottom fill implementation.
      * <p>Note: Currently only the first implementation registered will be provided. This may change in the future.</p>
      *
-     * @return THe first implementation specified. (Or the default if no custom ones were added).
+     * @return The first implementation specified. (Or the default if no custom ones were added).
      */
     public static BottomFillImpl provide() {
         if (!providers.isEmpty())

--- a/src/main/java/com/ryandw11/structure/bottomfill/BottomFillProvider.java
+++ b/src/main/java/com/ryandw11/structure/bottomfill/BottomFillProvider.java
@@ -1,0 +1,33 @@
+package com.ryandw11.structure.bottomfill;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides the plugin with an implementation of the BottomFill feature.
+ */
+public final class BottomFillProvider {
+    private final static List<BottomFillImpl> providers = new ArrayList<>();
+
+    /**
+     * Add a BottomFill implementation to the provider.
+     *
+     * @param bottomFill The bottom fill implementation.
+     */
+    public static void addProvider(BottomFillImpl bottomFill) {
+        providers.add(bottomFill);
+    }
+
+    /**
+     * Get a bottom fill implementation.
+     * <p>Note: Currently only the first implementation registered will be provided. This may change in the future.</p>
+     *
+     * @return THe first implementation specified. (Or the default if no custom ones were added).
+     */
+    public static BottomFillImpl provide() {
+        if (!providers.isEmpty())
+            return providers.get(0);
+
+        return new DefaultBottomFill();
+    }
+}

--- a/src/main/java/com/ryandw11/structure/bottomfill/DefaultBottomFill.java
+++ b/src/main/java/com/ryandw11/structure/bottomfill/DefaultBottomFill.java
@@ -1,0 +1,68 @@
+package com.ryandw11.structure.bottomfill;
+
+import com.ryandw11.structure.CustomStructures;
+import com.ryandw11.structure.structure.Structure;
+import org.bukkit.Location;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * The default implementation for the bottom fill feature.
+ */
+public class DefaultBottomFill extends BukkitRunnable implements BottomFillImpl {
+
+    private Location minLoc;
+    private Location maxLoc;
+    private Location location;
+    private Structure structure;
+    private int currentX;
+    private int currentY;
+    private int currentZ;
+    private BukkitTask bukkitTask;
+
+    @Override
+    public void performFill(Structure structure, Location spawnLocation, Location minLoc, Location maxLoc) {
+        if (structure.getBottomSpaceFill().getFillMaterial(spawnLocation.getBlock().getBiome()).isEmpty())
+            return;
+
+        this.structure = structure;
+        this.location = spawnLocation;
+        this.minLoc = new Location(minLoc.getWorld(), minLoc.getBlockX(), minLoc.getBlockY() - 1, minLoc.getBlockZ());
+        this.maxLoc = new Location(minLoc.getWorld(), maxLoc.getBlockX(), minLoc.getBlockY() - 1, maxLoc.getBlockZ());
+        currentX = minLoc.getBlockX();
+        currentY = minLoc.getBlockY() - 1;
+        currentZ = minLoc.getBlockZ();
+        bukkitTask = this.runTaskTimer(CustomStructures.getInstance(), 0, 1);
+    }
+
+    @Override
+    public void run() {
+        // TODO:: Make it so that if there is not block at the bottom of the structure, then there will not be ground placed.
+        for(int i = 0; i < 40; i++) {
+
+            if (!location.getWorld().getBlockAt(currentX, currentY, currentZ).isEmpty()
+                    && !CustomStructures.getInstance().getBlockIgnoreManager().getBlocks()
+                    .contains(location.getWorld().getBlockAt(currentX, currentY, currentZ).getType())) {
+                currentY = minLoc.getBlockY();
+                currentX++;
+            }
+
+            if (currentX > maxLoc.getBlockX()) {
+                currentX = minLoc.getBlockX();
+                currentZ++;
+            }
+
+            if (currentZ > maxLoc.getBlockZ()) {
+                this.cancel();
+                bukkitTask = null;
+                return;
+            }
+
+            if (structure.getBottomSpaceFill().getFillMaterial(location.getBlock().getBiome()).isPresent())
+                location.getWorld().getBlockAt(currentX, currentY, currentZ)
+                        .setType(structure.getBottomSpaceFill().getFillMaterial(location.getBlock().getBiome()).get());
+
+            currentY--;
+        }
+    }
+}

--- a/src/main/java/com/ryandw11/structure/bottomfill/DefaultBottomFill.java
+++ b/src/main/java/com/ryandw11/structure/bottomfill/DefaultBottomFill.java
@@ -3,6 +3,7 @@ package com.ryandw11.structure.bottomfill;
 import com.ryandw11.structure.CustomStructures;
 import com.ryandw11.structure.structure.Structure;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -38,11 +39,19 @@ public class DefaultBottomFill extends BukkitRunnable implements BottomFillImpl 
     @Override
     public void run() {
         // TODO:: Make it so that if there is not block at the bottom of the structure, then there will not be ground placed.
-        for(int i = 0; i < 40; i++) {
+        for (int i = 0; i < 40; i++) {
 
-            if (!location.getWorld().getBlockAt(currentX, currentY, currentZ).isEmpty()
-                    && !CustomStructures.getInstance().getBlockIgnoreManager().getBlocks()
-                    .contains(location.getWorld().getBlockAt(currentX, currentY, currentZ).getType())) {
+            if (
+                // If the block is not empty
+                    !location.getWorld().getBlockAt(currentX, currentY, currentZ).isEmpty()
+                            // and the block is not in the list of ignore blocks.
+                            && !CustomStructures.getInstance().getBlockIgnoreManager().getBlocks()
+                            .contains(location.getWorld().getBlockAt(currentX, currentY, currentZ).getType())
+                            // And not water (if it is set to be ignored)
+                            && !(structure.getStructureProperties().shouldIgnoreWater()
+                            && location.getWorld().getBlockAt(currentX, currentY, currentZ).getType() == Material.WATER)
+            ) {
+                // Then move on.
                 currentY = minLoc.getBlockY();
                 currentX++;
             }

--- a/src/main/java/com/ryandw11/structure/commands/SCommand.java
+++ b/src/main/java/com/ryandw11/structure/commands/SCommand.java
@@ -46,6 +46,7 @@ public class SCommand implements CommandExecutor {
         this.commandHandler.registerCommand("create", new CreateCommand(plugin));
         this.commandHandler.registerCommand("testspawn", new TestSpawnCommand(plugin));
         this.commandHandler.registerCommand(new AddonsCommand(plugin), "addon", "addons");
+        this.commandHandler.registerCommand(new SetLoottableCommand(plugin), "setloottable", "setloot", "setlt");
     }
 
     @Override
@@ -84,6 +85,8 @@ public class SCommand implements CommandExecutor {
                         "&3/cstructure create {name} {schematic} - &2Create a structure using the default settings."));
                 sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                         "&3/cstructure addon - &2The list of addons."));
+                sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        "&3/cstructure setLootTable - &2Easily specify a loot table for a container."));
             } else {
                 sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                         "&3=============[&2CustomStructures&3]============="));

--- a/src/main/java/com/ryandw11/structure/commands/SCommandTab.java
+++ b/src/main/java/com/ryandw11/structure/commands/SCommandTab.java
@@ -24,9 +24,15 @@ public class SCommandTab implements TabCompleter {
         if (args.length == 2 && (args[0].equalsIgnoreCase("test") || args[0].equalsIgnoreCase("testspawn"))) {
             completions = new ArrayList<>(plugin.getStructureHandler().getStructureNames());
             completions = getApplicableTabCompleter(args[1], completions);
+        } else if(args.length == 2 && (
+                args[0].equalsIgnoreCase("setLootTable") ||
+                        args[0].equalsIgnoreCase("setLoot") ||
+                        args[0].equalsIgnoreCase("setlt")))  {
+            completions = plugin.getLootTableHandler().getLootTablesNames();
+            completions = getApplicableTabCompleter(args[1], completions);
         } else if (args.length <= 1) {
             completions = new ArrayList<>(Arrays.asList("reload", "test", "list", "addItem", "checkKey", "getItem",
-                    "createSchem", "create", "nearby", "testspawn", "addons"));
+                    "createSchem", "create", "nearby", "testspawn", "addons", "setLootTable"));
             completions = getApplicableTabCompleter(args.length == 1 ? args[0] : "", completions);
         }
         Collections.sort(completions);

--- a/src/main/java/com/ryandw11/structure/commands/cstruct/AddonsCommand.java
+++ b/src/main/java/com/ryandw11/structure/commands/cstruct/AddonsCommand.java
@@ -7,8 +7,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -28,9 +26,7 @@ public class AddonsCommand implements SubCommand {
         this.plugin = plugin;
     }
 
-    private static final List<String> officialAddons = new ArrayList<>(Arrays.asList(
-            "CSCustomBiomes"
-    ));
+    private static final List<String> officialAddons = List.of("CSCustomBiomes", "CSFastFill");
 
     @Override
     public boolean subCommand(CommandSender sender, Command cmd, String s, String[] args) {

--- a/src/main/java/com/ryandw11/structure/commands/cstruct/SetLoottableCommand.java
+++ b/src/main/java/com/ryandw11/structure/commands/cstruct/SetLoottableCommand.java
@@ -1,0 +1,74 @@
+package com.ryandw11.structure.commands.cstruct;
+
+import com.ryandw11.structure.CustomStructures;
+import com.ryandw11.structure.commands.SubCommand;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * The Add Item command for the plugin.
+ *
+ * <p>Permission: customstructures.setloottable</p>
+ *
+ * <code>
+ * /cstruct setloottable {lootTableName}
+ * </code>
+ */
+public class SetLoottableCommand implements SubCommand {
+
+    private final CustomStructures plugin;
+
+    public SetLoottableCommand(CustomStructures plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean subCommand(CommandSender sender, Command cmd, String s, String[] args) {
+        if (args.length == 0) {
+            if (!sender.hasPermission("customstructures.setloottable")) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission for this command!");
+                return true;
+            }
+            sender.sendMessage(ChatColor.RED + "You must specify the loot table for the chest to have.");
+        } else if (args.length == 1) {
+            if (!sender.hasPermission("customstructures.setloottable")) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission for this command!");
+                return true;
+            }
+            if (!(sender instanceof Player p)) {
+                sender.sendMessage(ChatColor.RED + "This command is for players only!");
+                return true;
+            }
+
+            if(plugin.getLootTableHandler().getLootTableByName(args[0]) == null) {
+                sender.sendMessage(ChatColor.RED + "Cannot find specified loot table. Check to make sure that it exists.");
+                return true;
+            }
+
+            Block block = p.getTargetBlock(null, 20);
+            if(!(block.getState() instanceof Container container)) {
+                sender.sendMessage(ChatColor.RED + "You must be looking at a container to set its loot table.");
+                return true;
+            }
+            container.getInventory().clear();
+            ItemStack paper = new ItemStack(Material.PAPER, 1);
+            ItemMeta itemMeta = paper.getItemMeta();
+            itemMeta.setDisplayName("%${" + args[0] + "}$%");
+            itemMeta.setLore(List.of("Defines a specific loot table for this container to use.", "This must be in the first item slot to work."));
+            paper.setItemMeta(itemMeta);
+            container.getInventory().setItem(0, paper);
+            sender.sendMessage(ChatColor.GREEN + "The loot table item has been added to the container!");
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/ryandw11/structure/ignoreblocks/IgnoreBlocks_1_19.java
+++ b/src/main/java/com/ryandw11/structure/ignoreblocks/IgnoreBlocks_1_19.java
@@ -2,17 +2,16 @@ package com.ryandw11.structure.ignoreblocks;
 
 import org.bukkit.Material;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
- * Ignore blocks for 1.17 - 1.18
+ * Ignore blocks for 1.19
+ * <p>
+ * TODO Maybe use built in list defined by data packs? Or have the option
  */
-public class IgnoreBlocks_1_17 implements IgnoreBlocks {
+public class IgnoreBlocks_1_19 implements IgnoreBlocks {
 
-    private final List<Material> plantBlocks = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(
+    private final List<Material> ignoreBlocks = List.of(
             // General BLocks
             Material.SNOW,
             // Grasses
@@ -106,11 +105,18 @@ public class IgnoreBlocks_1_17 implements IgnoreBlocks {
             Material.SMALL_AMETHYST_BUD,
             Material.MEDIUM_AMETHYST_BUD,
             Material.LARGE_AMETHYST_BUD,
-            Material.AMETHYST_CLUSTER
-    )));
+            Material.AMETHYST_CLUSTER,
+            // New 1.19 Materials
+            Material.MANGROVE_ROOTS,
+            Material.MUDDY_MANGROVE_ROOTS,
+            Material.MANGROVE_LOG,
+            Material.MANGROVE_LEAVES,
+            Material.MANGROVE_PROPAGULE,
+            Material.SCULK_VEIN
+    );
 
     @Override
     public List<Material> getBlocks() {
-        return plantBlocks;
+        return ignoreBlocks;
     }
 }

--- a/src/main/java/com/ryandw11/structure/listener/ChunkLoad.java
+++ b/src/main/java/com/ryandw11/structure/listener/ChunkLoad.java
@@ -35,7 +35,11 @@ public class ChunkLoad implements Listener {
          * Schematic handler
          * This activity is done async to prevent the server from lagging.
          */
-        StructurePicker s = new StructurePicker(b, e.getChunk(), CustomStructures.getInstance());
-        s.runTaskTimer(CustomStructures.plugin, 1, 10);
+        try {
+            StructurePicker s = new StructurePicker(b, e.getChunk(), CustomStructures.getInstance());
+            s.runTaskTimer(CustomStructures.plugin, 1, 10);
+        } catch (RuntimeException ex) {
+            // ignore, error already logged.
+        }
     }
 }

--- a/src/main/java/com/ryandw11/structure/loottables/LootTable.java
+++ b/src/main/java/com/ryandw11/structure/loottables/LootTable.java
@@ -3,6 +3,7 @@ package com.ryandw11.structure.loottables;
 import com.ryandw11.structure.CustomStructures;
 import com.ryandw11.structure.exceptions.LootTableException;
 import com.ryandw11.structure.utils.RandomCollection;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;

--- a/src/main/java/com/ryandw11/structure/loottables/LootTablesHandler.java
+++ b/src/main/java/com/ryandw11/structure/loottables/LootTablesHandler.java
@@ -4,9 +4,7 @@ import com.ryandw11.structure.CustomStructures;
 import com.ryandw11.structure.api.CustomStructuresAPI;
 import com.ryandw11.structure.exceptions.LootTableException;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This handles the loot tables.
@@ -50,5 +48,14 @@ public class LootTablesHandler {
      */
     public Map<String, LootTable> getLootTables() {
         return Collections.unmodifiableMap(lootTables);
+    }
+
+    /**
+     * Get a list with the names of all loot tables.
+     *
+     * @return The list with names of all loot tables.
+     */
+    public List<String> getLootTablesNames() {
+        return new ArrayList<>(this.lootTables.keySet());
     }
 }

--- a/src/main/java/com/ryandw11/structure/mythicalmobs/MMDisabled.java
+++ b/src/main/java/com/ryandw11/structure/mythicalmobs/MMDisabled.java
@@ -6,12 +6,12 @@ import org.bukkit.Location;
 public class MMDisabled implements MythicalMobHook{
 
 	@Override
-	public void spawnMob(String name, Location loc) {
+	public void spawnMob(String name, Location loc, int count) {
 		Bukkit.getLogger().info("A schematic tried to spawn a MythicMob, but the server does not have that plugin installed!");
 	}
 
 	@Override
-	public void spawnMob(String name, Location loc, int level) {
+	public void spawnMob(String name, Location loc, double level, int count) {
 		Bukkit.getLogger().info("A schematic tried to spawn a MythicMob, but the server does not have that plugin installed!");
 	}
 

--- a/src/main/java/com/ryandw11/structure/mythicalmobs/MMEnabled.java
+++ b/src/main/java/com/ryandw11/structure/mythicalmobs/MMEnabled.java
@@ -1,22 +1,36 @@
 package com.ryandw11.structure.mythicalmobs;
 
+import io.lumine.mythic.api.MythicProvider;
+import io.lumine.mythic.api.mobs.MythicMob;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
-import io.lumine.xikage.mythicmobs.MythicMobs;
-import io.lumine.xikage.mythicmobs.mobs.MobManager;
+import java.util.Optional;
+
 
 public class MMEnabled implements MythicalMobHook {
 
-	@Override
-	public void spawnMob(String name, Location loc) {
-		MobManager mobManager = MythicMobs.inst().getMobManager();
-		mobManager.spawnMob(name, loc);
-	}
+    @Override
+    public void spawnMob(String name, Location loc, int count) {
+        Optional<MythicMob> mob = MythicProvider.get().getMobManager().getMythicMob(name);
+        if (mob.isPresent()) {
+			for(int i = 0; i < count; i++)
+				mob.get().spawn(BukkitAdapter.adapt(loc), 1);
+		}
+        else
+            Bukkit.getLogger().warning("Unknown Mythical Mob: " + name);
+    }
 
-	@Override
-	public void spawnMob(String name, Location loc, int level) {
-		MobManager mobManager = MythicMobs.inst().getMobManager();
-		mobManager.spawnMob(name, loc, level);
-	}
+    @Override
+    public void spawnMob(String name, Location loc, double level, int count) {
+        Optional<MythicMob> mob = MythicProvider.get().getMobManager().getMythicMob(name);
+        if (mob.isPresent()) {
+			for(int i = 0; i < count; i++)
+				mob.get().spawn(BukkitAdapter.adapt(loc), level);
+		}
+        else
+            Bukkit.getLogger().warning("Unknown Mythical Mob: " + name);
+    }
 
 }

--- a/src/main/java/com/ryandw11/structure/mythicalmobs/MMEnabled.java
+++ b/src/main/java/com/ryandw11/structure/mythicalmobs/MMEnabled.java
@@ -15,10 +15,9 @@ public class MMEnabled implements MythicalMobHook {
     public void spawnMob(String name, Location loc, int count) {
         Optional<MythicMob> mob = MythicProvider.get().getMobManager().getMythicMob(name);
         if (mob.isPresent()) {
-			for(int i = 0; i < count; i++)
-				mob.get().spawn(BukkitAdapter.adapt(loc), 1);
-		}
-        else
+            for (int i = 0; i < count; i++)
+                mob.get().spawn(BukkitAdapter.adapt(loc), 1);
+        } else
             Bukkit.getLogger().warning("Unknown Mythical Mob: " + name);
     }
 
@@ -26,10 +25,9 @@ public class MMEnabled implements MythicalMobHook {
     public void spawnMob(String name, Location loc, double level, int count) {
         Optional<MythicMob> mob = MythicProvider.get().getMobManager().getMythicMob(name);
         if (mob.isPresent()) {
-			for(int i = 0; i < count; i++)
-				mob.get().spawn(BukkitAdapter.adapt(loc), level);
-		}
-        else
+            for (int i = 0; i < count; i++)
+                mob.get().spawn(BukkitAdapter.adapt(loc), level);
+        } else
             Bukkit.getLogger().warning("Unknown Mythical Mob: " + name);
     }
 

--- a/src/main/java/com/ryandw11/structure/mythicalmobs/MythicalMobHook.java
+++ b/src/main/java/com/ryandw11/structure/mythicalmobs/MythicalMobHook.java
@@ -3,6 +3,6 @@ package com.ryandw11.structure.mythicalmobs;
 import org.bukkit.Location;
 
 public interface MythicalMobHook {
-	void spawnMob(String name, Location loc);
-	void spawnMob(String name, Location loc, int level);
+	void spawnMob(String name, Location loc, int count);
+	void spawnMob(String name, Location loc, double level, int count);
 }

--- a/src/main/java/com/ryandw11/structure/structure/Structure.java
+++ b/src/main/java/com/ryandw11/structure/structure/Structure.java
@@ -41,6 +41,7 @@ public class Structure {
     private final StructureLimitations structureLimitations;
     private final MaskProperty maskProperty;
     private final SubSchematics subSchematics;
+    private final BottomSpaceFill bottomSpaceFill;
     private final Map<LootTableType, RandomCollection<LootTable>> lootTables;
     private final List<StructureSection> structureSections;
     private final double baseRotation;
@@ -64,6 +65,7 @@ public class Structure {
         this.structureLimitations = builder.structureLimitations;
         this.maskProperty = builder.maskProperty;
         this.subSchematics = builder.subSchematics;
+        this.bottomSpaceFill = builder.bottomSpaceFill;
         this.lootTables = builder.lootTables;
         this.structureSections = builder.structureSections;
         this.baseRotation = builder.baseRotation;
@@ -169,6 +171,15 @@ public class Structure {
      */
     public SubSchematics getSubSchematics() {
         return subSchematics;
+    }
+
+    /**
+     * Get the bottom space fill configuration section.
+     *
+     * @return The bottom space fill section.
+     */
+    public BottomSpaceFill getBottomSpaceFill() {
+        return bottomSpaceFill;
     }
 
     /**

--- a/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
+++ b/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
@@ -51,6 +51,7 @@ public class StructureBuilder {
     protected StructureLimitations structureLimitations;
     protected MaskProperty maskProperty;
     protected SubSchematics subSchematics;
+    protected BottomSpaceFill bottomSpaceFill;
     protected Map<LootTableType, RandomCollection<LootTable>> lootTables;
     protected List<StructureSection> structureSections;
     // Base Rotation in Radians.
@@ -124,6 +125,8 @@ public class StructureBuilder {
         structureLimitations = new StructureLimitations(config);
         maskProperty = new MaskProperty(config);
         subSchematics = new SubSchematics(config, CustomStructures.getInstance());
+        bottomSpaceFill = new BottomSpaceFill(config);
+
         lootTables = new HashMap<>();
         if (config.contains("LootTables")) {
             ConfigurationSection lootableConfig = config.getConfigurationSection("LootTables");
@@ -283,6 +286,15 @@ public class StructureBuilder {
      */
     public void setMaskProperty(MaskProperty mask) {
         this.maskProperty = mask;
+    }
+
+    /**
+     * Set the bottom space fill property.
+     *
+     * @param bottomSpaceFill The bottom space fill property.
+     */
+    public void setBottomSpaceFill(BottomSpaceFill bottomSpaceFill) {
+        this.bottomSpaceFill = bottomSpaceFill;
     }
 
     /**

--- a/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
+++ b/src/main/java/com/ryandw11/structure/structure/StructureBuilder.java
@@ -38,7 +38,7 @@ import java.util.*;
 public class StructureBuilder {
 
     private FileConfiguration config;
-    private CustomStructures plugin;
+    private final CustomStructures plugin;
 
     protected String name;
     protected String schematic;

--- a/src/main/java/com/ryandw11/structure/structure/properties/BottomSpaceFill.java
+++ b/src/main/java/com/ryandw11/structure/structure/properties/BottomSpaceFill.java
@@ -1,0 +1,138 @@
+package com.ryandw11.structure.structure.properties;
+
+import com.ryandw11.structure.exceptions.StructureConfigurationException;
+import org.bukkit.Material;
+import org.bukkit.block.Biome;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents the BottomSpaceFill configuration section.
+ *
+ * <p>This option allows for the structure to have blocks placed under it when a portion is floating.</p>
+ */
+public class BottomSpaceFill {
+    private final Map<Biome, Material> blockMap;
+    private Material defaultMaterial;
+    private boolean enabled = false;
+
+    /**
+     * Used by the StructureBuilder when there is a structure configuration file.
+     *
+     * @param configuration The file configuration for the structure config.
+     */
+    public BottomSpaceFill(FileConfiguration configuration) {
+        blockMap = new HashMap<>();
+
+        if (!configuration.contains("BottomSpaceFill")) {
+            return;
+        }
+
+        ConfigurationSection fillSection = Objects.requireNonNull(configuration.getConfigurationSection("BottomSpaceFill"));
+
+        enabled = true;
+
+        for (String keyGroup : fillSection.getKeys(false)) {
+            String[] keys = keyGroup.split(",");
+            Material fillMaterial;
+            try {
+                fillMaterial = Material.valueOf(Objects.requireNonNull(fillSection.getString(keyGroup)).toUpperCase());
+            } catch (IllegalArgumentException ex) {
+                throw new StructureConfigurationException("Unknown fill material " + fillSection.getString(keyGroup) + " in BottomSpaceFill configuration section.");
+            }
+
+            for (String key : keys) {
+                if (key.equalsIgnoreCase("default")) {
+                    defaultMaterial = fillMaterial;
+                    continue;
+                }
+
+                Biome biome;
+                try {
+                    biome = Biome.valueOf(key.toUpperCase());
+                } catch (IllegalArgumentException ex) {
+                    throw new StructureConfigurationException("Unknown biome " + key + " in BottomSpaceFill configuration section.");
+                }
+                blockMap.put(biome, fillMaterial);
+            }
+        }
+    }
+
+    /**
+     * Construct a bottom space fill configuration that is disabled.
+     *
+     * <p>You should use this if you don't want your structures to have bottom filling.</p>
+     */
+    public BottomSpaceFill() {
+        enabled = false;
+        this.blockMap = new HashMap<>();
+    }
+
+    /**
+     * Construct a bottom space fill configuration with the desired value.
+     *
+     * @param defaultMaterial The default material to be used if a biome is not specified. (Null if you don't want any).
+     * @param blockFillMap    The block fill map for the structure.
+     */
+    public BottomSpaceFill(@Nullable Material defaultMaterial, @NotNull Map<Biome, Material> blockFillMap) {
+        enabled = true;
+        this.defaultMaterial = defaultMaterial;
+        this.blockMap = Objects.requireNonNull(blockFillMap);
+    }
+
+    /**
+     * Check if the structure has bottom space filling enabled.
+     *
+     * @return If the structure has bottom space filling enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Set the fill material for any biome not explicitly stated. (If null, then no fill is performed for non-specified biomes).
+     *
+     * @param material The material to use for the fill.
+     */
+    public void setDefaultFillMaterial(@Nullable Material material) {
+        this.defaultMaterial = material;
+    }
+
+    /**
+     * The fill material for any biome not explicitly stated. (If none, then no fill is performed for non-specified biomes).
+     *
+     * @return The fill material for any biome not explicitly stated.
+     */
+    public Optional<Material> getDefaultFillMaterial() {
+        return Optional.ofNullable(defaultMaterial);
+    }
+
+    /**
+     * Get the fill block map.
+     *
+     * @return The fill block map.
+     */
+    @NotNull
+    public Map<Biome, Material> getFillBlockMap() {
+        return this.blockMap;
+    }
+
+    /**
+     * Get the fill material for a specific biome.
+     *
+     * @param biome The biome to get the fill material for.
+     * @return An optional containing the Material. (If none, then no fill exists for that biome).
+     */
+    public Optional<Material> getFillMaterial(Biome biome) {
+        if (blockMap.containsKey(biome))
+            return Optional.of(blockMap.get(biome));
+        return Optional.ofNullable(defaultMaterial);
+    }
+}

--- a/src/main/java/com/ryandw11/structure/structure/properties/StructureLimitations.java
+++ b/src/main/java/com/ryandw11/structure/structure/properties/StructureLimitations.java
@@ -11,6 +11,7 @@ import java.util.*;
  */
 public class StructureLimitations {
 
+    private int iterationLimit;
     private final List<String> whitelistSpawnBlocks;
     private final List<String> blacklistSpawnBlocks;
     private final BlockLevelLimit blockLevelLimit;
@@ -24,6 +25,11 @@ public class StructureLimitations {
      * @param configuration The configuration to create from.
      */
     public StructureLimitations(FileConfiguration configuration) {
+        if (!configuration.contains("StructureLimitations.iterationLimit"))
+            iterationLimit = 2;
+        else
+            iterationLimit = configuration.getInt("StructureLimitations.iterationLimit");
+
         if (!configuration.contains("StructureLimitations.whitelistSpawnBlocks"))
             whitelistSpawnBlocks = new ArrayList<>();
         else
@@ -58,10 +64,29 @@ public class StructureLimitations {
      * @param blockReplacement     The block replacement map.
      */
     public StructureLimitations(List<String> whitelistSpawnBlocks, List<String> blacklistSpawnBlocks, BlockLevelLimit blockLevelLimit, Map<Material, Material> blockReplacement) {
+        this.iterationLimit = 2;
         this.whitelistSpawnBlocks = whitelistSpawnBlocks;
         this.blacklistSpawnBlocks = blacklistSpawnBlocks;
         this.blockLevelLimit = blockLevelLimit;
         this.blockReplacement = blockReplacement;
+    }
+
+    /**
+     * Set the iteration limit for the structure.
+     *
+     * @param iterationLimit The iteration limit.
+     */
+    public void setIterationLimit(int iterationLimit) {
+        this.iterationLimit = iterationLimit;
+    }
+
+    /**
+     * Get the iteration limit for the structure.
+     *
+     * @return The iteration limit.
+     */
+    public int getIterationLimit() {
+        return this.iterationLimit;
     }
 
     /**

--- a/src/main/java/com/ryandw11/structure/structure/properties/StructureProperties.java
+++ b/src/main/java/com/ryandw11/structure/structure/properties/StructureProperties.java
@@ -14,6 +14,7 @@ public class StructureProperties {
     private boolean spawnInWater;
     private boolean spawnInLavaLakes;
     private boolean spawnInVoid;
+    private boolean ignoreWater;
 
     /**
      * Create StructureProperties from a config file.
@@ -37,6 +38,7 @@ public class StructureProperties {
         this.spawnInWater = cs.contains("spawnInWater") && cs.getBoolean("spawnInWater");
         this.spawnInLavaLakes = cs.contains("spawnInLavaLakes") && cs.getBoolean("spawnInLavaLakes");
         this.spawnInVoid = cs.contains("spawnInVoid") && cs.getBoolean("spawnInVoid");
+        this.ignoreWater = cs.contains("ignoreWater") && cs.getBoolean("ignoreWater");
     }
 
     /**
@@ -49,6 +51,7 @@ public class StructureProperties {
         this.spawnInWater = true;
         this.spawnInLavaLakes = true;
         this.spawnInVoid = false;
+        this.ignoreWater = false;
     }
 
     /**
@@ -159,5 +162,23 @@ public class StructureProperties {
      */
     public void setSpawnInVoid(boolean spawnInVoid) {
         this.spawnInVoid = spawnInVoid;
+    }
+
+    /**
+     * Get if the structure should ignore water.
+     *
+     * @return If the structure should ignore water.
+     */
+    public boolean shouldIgnoreWater() {
+        return ignoreWater;
+    }
+
+    /**
+     * Set if the structure should ignore water.
+     *
+     * @param ignoreWater If the structure should ignore water.
+     */
+    public void setIgnoreWater(boolean ignoreWater) {
+        this.ignoreWater = ignoreWater;
     }
 }

--- a/src/main/java/com/ryandw11/structure/structure/properties/StructureYSpawning.java
+++ b/src/main/java/com/ryandw11/structure/structure/properties/StructureYSpawning.java
@@ -8,7 +8,6 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**

--- a/src/main/java/com/ryandw11/structure/structure/properties/StructureYSpawning.java
+++ b/src/main/java/com/ryandw11/structure/structure/properties/StructureYSpawning.java
@@ -73,6 +73,7 @@ public class StructureYSpawning {
 
     /**
      * Get the SpawnY Height Map.
+     *
      * @return The SpawnY Height Map.
      */
     public HeightMap getHeightMap() {
@@ -159,10 +160,11 @@ public class StructureYSpawning {
                     int num1 = Integer.parseInt(out[0]);
                     int num2 = Integer.parseInt(out[1]);
 
-                    Random r = new Random();
+                    if (num1 > num2)
+                        throw new StructureConfigurationException("SpawnY Value 1 must be greater than value 2 in '[value1;value2]'.");
 
-                    int a = r.nextInt(num2) + (num1 + 1);
-                    return currentHeight + a;
+                    int randomValue = ThreadLocalRandom.current().nextInt(num1, num2 + 1);
+                    return currentHeight + randomValue;
 
                 } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
                     return currentHeight;
@@ -176,10 +178,11 @@ public class StructureYSpawning {
                     int num1 = Integer.parseInt(out[0]);
                     int num2 = Integer.parseInt(out[1]);
 
-                    Random r = new Random();
+                    if (num1 > num2)
+                        throw new StructureConfigurationException("SpawnY Value 1 must be greater than value 2 in '[value1;value2]'.");
 
-                    int a = r.nextInt(num2) + (num1 + 1);
-                    return currentHeight - a;
+                    int randomValue = ThreadLocalRandom.current().nextInt(num1, num2 + 1);
+                    return currentHeight - randomValue;
 
                 } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
                     return currentHeight;
@@ -192,6 +195,9 @@ public class StructureYSpawning {
                 try {
                     int num1 = Integer.parseInt(out[0]);
                     int num2 = Integer.parseInt(out[1]);
+
+                    if (num1 > num2)
+                        throw new StructureConfigurationException("SpawnY Value 1 must be greater than value 2 in '[value1;value2]'.");
 
                     return ThreadLocalRandom.current().nextInt(num1, num2 + 1);
 

--- a/src/main/java/com/ryandw11/structure/utils/StructurePicker.java
+++ b/src/main/java/com/ryandw11/structure/utils/StructurePicker.java
@@ -10,8 +10,6 @@ import com.ryandw11.structure.structure.StructureHandler;
 import com.ryandw11.structure.structure.properties.BlockLevelLimit;
 import com.ryandw11.structure.structure.properties.StructureYSpawning;
 import com.sk89q.worldedit.WorldEditException;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -51,16 +49,9 @@ public class StructurePicker extends BukkitRunnable {
         this.ignoreBlocks = plugin.getBlockIgnoreManager();
 
         if (this.structureHandler == null) {
-            Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&',
-                    "&b[&aCustomStructures&b] &cA fatal error has occurred! Please check the console for errors."));
-            plugin.getLogger().severe("A fatal error has occurred!");
-            plugin.getLogger().severe("It appears that the plugin's setup process was not completed successfully.");
-            plugin.getLogger().severe("Try restarting the server or updating to the latest version of the server software.");
-            plugin.getLogger().severe("The plugin will now be disabled");
-            if (plugin.isDebug()) {
-                plugin.getLogger().severe("[DEBUG] CustomStructures#structureHandler was null when the StructurePicker was created.");
-            }
-            Bukkit.getPluginManager().disablePlugin(plugin);
+            plugin.getLogger().warning("A structure is trying to spawn without the plugin initialization step being completed.");
+            plugin.getLogger().warning("If you are using a fork of Spigot, this likely means that the fork does not adhere to the API standard properly.");
+            throw new RuntimeException("Plugin Not Initialized.");
         }
     }
 
@@ -132,7 +123,7 @@ public class StructurePicker extends BukkitRunnable {
             if (!structure.getStructureLimitations().hasWhitelistBlock(structureBlock))
                 return;
 
-            if(structure.getStructureLimitations().hasBlacklistBlock(structureBlock))
+            if (structure.getStructureLimitations().hasBlacklistBlock(structureBlock))
                 return;
 
             // If it can spawn in water

--- a/src/main/java/com/ryandw11/structure/utils/StructurePicker.java
+++ b/src/main/java/com/ryandw11/structure/utils/StructurePicker.java
@@ -183,9 +183,9 @@ public class StructurePicker extends BukkitRunnable {
                 try {
                     if (!section.checkStructureConditions(structure, structureBlock, ch)) return;
                 } catch (Exception ex) {
-                    plugin.getLogger().severe(String.format("[CS Addon] An error has occurred when attempting to spawn" +
+                    plugin.getLogger().severe(String.format("[CS Addon] An error has occurred when attempting to spawn " +
                             "the structure %s with the custom property %s!", structure.getName(), section.getName()));
-                    plugin.getLogger().severe("This is not a CustomStructures error! Please report" +
+                    plugin.getLogger().severe("This is not a CustomStructures error! Please report " +
                             "this to the developer of the addon.");
                     if (plugin.isDebug()) {
                         ex.printStackTrace();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CustomStructures
-version: 1.7.1.1
+version: 1.8.0
 main: com.ryandw11.structure.CustomStructures
 author: Ryandw11
 description: A plugin which allows you to spawn in custom structures!

--- a/src/main/resources/structures/demo.yml
+++ b/src/main/resources/structures/demo.yml
@@ -69,6 +69,11 @@ Masks:
   NegatedBlockMask:
     - WHITE_WOOL
 
+BottomSpaceFill:
+  'SNOWY_TAIGA,SNOWY_PLAINS': SNOW_BLOCK
+  'DESERT': SANDSTONE
+  'default': DIRT
+
 
 #List of lootTables for this Schematic, name and weight
 #Weight determines how often it will be chosen out of all the entries in the list.

--- a/src/main/resources/structures/demo.yml
+++ b/src/main/resources/structures/demo.yml
@@ -24,6 +24,7 @@ StructureProperties:
   spawnInWater: true
   spawnInLavaLakes: true
   spawnInVoid: false
+  ignoreWater: false
 
 SubSchematics:
   Enabled: false


### PR DESCRIPTION
**Changes:**
- Plugin now requires Java 16 (Closes #141)
- MythicMobs has been fixed (Closes #140)
- Mob signs can now spawn multiple mobs.
- Allow for a customizable subschematic recursion limit. (Closes #134)
- Handles SpawnY out of bounds errors in a nicer way.
- Added the ability for structures to have a bottom fill. (Closes #106, Closes #101)
- Added the ability for per container loot tables. (Closes #132)
- Now silently fails if a structure tries to spawn before initialization (Closes #118)
- Enhanced 1.19 support.